### PR TITLE
Update install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,4 +14,4 @@ Download using the [GitHub .zip download](https://github.com/dracula/micro/archi
 
 1. Place `dracula.micro` into `~/.config/micro/colorschemes` (create the folder if it doesn't exist).
 2. Add `export MICRO_TRUECOLOR=1` to your shell RC file (eg. bashrc, zshrc, config.fish).
-3. Start a new instance of Micro, if the theme isn't available, press `Ctrl+e` to bring up the command prompt, type in `set colorscheme dracula` and execute (press `Enter`).
+3. Start a new instance of Micro, if the theme isn't available, press `Ctrl+e` to bring up the command prompt, type in `set colorscheme dracula-tc` and execute (press `Enter`).


### PR DESCRIPTION
> If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

I followed the instructions on `INSTALL.md` but after entering `set colorscheme dracula` i got this error: 

![Screenshot from 2023-06-03 18-47-32](https://github.com/dracula/micro/assets/77718741/f0c4a9e9-de05-4f67-ad9d-c9c56eb23106)

I later figured out that the name of the theme in micro is `dracula-tc` and after entering `set colorscheme dracula-tc` it works as intended.

So i updated INSTALL instructions with the correct theme name.